### PR TITLE
Fix missing refine prompt

### DIFF
--- a/gia_app.py
+++ b/gia_app.py
@@ -80,6 +80,8 @@ ENGLISCH_REFINE_PROMPT_TMPL = (
     "If the new context is not useful, repeat exactly the original answer.\n"
 )
 
+ENGLISCH_REFINE_PROMPT = RefinePrompt(ENGLISCH_REFINE_PROMPT_TMPL)
+
 
 # Time function
 def timeit(func):


### PR DESCRIPTION
## Summary
- define `ENGLISCH_REFINE_PROMPT` using `RefinePrompt`

## Testing
- `python -m py_compile gia_app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f354eb0448322bc152b456fcf2ca0